### PR TITLE
仕様と実装の整合性改善: エラーコード/Docs挙動を修正

### DIFF
--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -35,7 +35,7 @@ func (c *CalendarCalendarsCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	resp, err := svc.CalendarList.List().Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "calendars_error", err.Error())
+		return writeGoogleAPIError("calendars_error", err)
 	}
 
 	type calendarInfo struct {
@@ -152,7 +152,7 @@ func (c *CalendarListCmd) Run(ctx context.Context, _ *RootFlags) error {
 	})
 
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "list_error", err.Error())
+		return writeGoogleAPIError("list_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
@@ -176,7 +176,7 @@ func (c *CalendarGetCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	event, err := svc.Events.Get(c.CalendarID, c.EventID).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "get_error", err.Error())
+		return writeGoogleAPIError("get_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, event)
@@ -235,7 +235,7 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, root *RootFlags) error {
 
 	created, err := svc.Events.Insert(c.CalendarID, event).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "create_error", err.Error())
+		return writeGoogleAPIError("create_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
@@ -300,7 +300,7 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, root *RootFlags) error {
 	// Fetch existing event.
 	event, err := svc.Events.Get(c.CalendarID, c.EventID).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "get_error", err.Error())
+		return writeGoogleAPIError("get_error", err)
 	}
 
 	if c.Title != "" {
@@ -325,7 +325,7 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, root *RootFlags) error {
 
 	updated, err := svc.Events.Update(c.CalendarID, c.EventID, event).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "update_error", err.Error())
+		return writeGoogleAPIError("update_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
@@ -365,7 +365,7 @@ func (c *CalendarDeleteCmd) Run(ctx context.Context, root *RootFlags) error {
 	}
 
 	if err := svc.Events.Delete(c.CalendarID, c.EventID).Do(); err != nil {
-		return output.WriteError(output.ExitCodeError, "delete_error", err.Error())
+		return writeGoogleAPIError("delete_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -2,11 +2,29 @@ package cmd
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/morikubo-takashi/gog-lite/internal/googleapi"
+	"github.com/morikubo-takashi/gog-lite/internal/output"
+	gapi "google.golang.org/api/googleapi"
 )
 
 // isAuthErr checks if err is an *googleapi.AuthRequiredError and sets target.
 func isAuthErr(err error, target **googleapi.AuthRequiredError) bool {
 	return errors.As(err, target)
+}
+
+// writeGoogleAPIError maps common Google API HTTP errors to exit codes.
+func writeGoogleAPIError(defaultCode string, err error) error {
+	var apiErr *gapi.Error
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case http.StatusNotFound:
+			return output.WriteError(output.ExitCodeNotFound, "not_found", err.Error())
+		case http.StatusForbidden:
+			return output.WriteError(output.ExitCodePermission, "permission_denied", err.Error())
+		}
+	}
+
+	return output.WriteError(output.ExitCodeError, defaultCode, err.Error())
 }

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -65,12 +65,12 @@ func (c *GmailSearchCmd) Run(ctx context.Context, _ *RootFlags) error {
 	})
 
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "search_error", err.Error())
+		return writeGoogleAPIError("search_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
-		"messages":       messages,
-		"nextPageToken":  nextPageToken,
+		"messages":      messages,
+		"nextPageToken": nextPageToken,
 	})
 }
 
@@ -89,7 +89,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	msg, err := svc.Users.Messages.Get("me", c.MessageID).Format(c.Format).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "get_error", err.Error())
+		return writeGoogleAPIError("get_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, msg)
@@ -144,7 +144,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	msg, err := svc.Users.Messages.Send("me", &gmail.Message{Raw: raw}).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "send_error", err.Error())
+		return writeGoogleAPIError("send_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
@@ -169,7 +169,7 @@ func (c *GmailThreadCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	thread, err := svc.Users.Threads.Get("me", c.ThreadID).Format(c.Format).Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "thread_error", err.Error())
+		return writeGoogleAPIError("thread_error", err)
 	}
 
 	return output.WriteJSON(os.Stdout, thread)
@@ -188,7 +188,7 @@ func (c *GmailLabelsCmd) Run(ctx context.Context, _ *RootFlags) error {
 
 	resp, err := svc.Users.Labels.List("me").Do()
 	if err != nil {
-		return output.WriteError(output.ExitCodeError, "labels_error", err.Error())
+		return writeGoogleAPIError("labels_error", err)
 	}
 
 	type labelInfo struct {


### PR DESCRIPTION
## 概要
AGENTS.md と実装を突き合わせ、仕様とのズレを修正しました。

## 変更内容
- Google APIのHTTPエラーを終了コードへ正しくマップ
  - 404 -> exit code 3 (not_found)
  - 403 -> exit code 4 (permission_denied)
  - 対象: gmail/calendar/docs 各コマンド
- docs cat の truncated 判定を修正
  - 文字数が max-bytes ちょうどのときに誤って true になる問題を解消
- docs export のヘルプ文言を実装に合わせて更新
  - odt, html を明記

## 検証
- go test ./... 実行済み（全パッケージ pass, test file なし）

## 備考
- ワークツリーに既存の未追跡ファイル gog-lite は変更していません。