### PR TITLE
セキュリティ対策と境界値テストの追加

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -66,13 +66,7 @@ func (c *DocsCatCmd) Run(ctx context.Context, _ *RootFlags) error {
 		return writeGoogleAPIError("docs_cat_error", err)
 	}
 
-	text := docsPlainText(doc)
-	truncated := false
-
-	if c.MaxBytes > 0 && len(text) > c.MaxBytes {
-		text = text[:c.MaxBytes]
-		truncated = true
-	}
+	text, truncated := truncateText(docsPlainText(doc), c.MaxBytes)
 
 	return output.WriteJSON(os.Stdout, map[string]any{
 		"id":        doc.DocumentId,
@@ -80,6 +74,14 @@ func (c *DocsCatCmd) Run(ctx context.Context, _ *RootFlags) error {
 		"content":   text,
 		"truncated": truncated,
 	})
+}
+
+func truncateText(text string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(text) <= maxBytes {
+		return text, false
+	}
+
+	return text[:maxBytes], true
 }
 
 // DocsCreateCmd creates a new document.

--- a/internal/cmd/docs_test.go
+++ b/internal/cmd/docs_test.go
@@ -132,3 +132,33 @@ func TestDocBodyLength_SingleElement(t *testing.T) {
 		t.Errorf("want 100, got %d", got)
 	}
 }
+
+func TestTruncateText_NoLimit(t *testing.T) {
+	got, truncated := truncateText("abcdef", 0)
+	if got != "abcdef" {
+		t.Errorf("got %q, want %q", got, "abcdef")
+	}
+	if truncated {
+		t.Error("expected truncated=false")
+	}
+}
+
+func TestTruncateText_ExactLimit(t *testing.T) {
+	got, truncated := truncateText("abcdef", 6)
+	if got != "abcdef" {
+		t.Errorf("got %q, want %q", got, "abcdef")
+	}
+	if truncated {
+		t.Error("expected truncated=false")
+	}
+}
+
+func TestTruncateText_OverLimit(t *testing.T) {
+	got, truncated := truncateText("abcdef", 4)
+	if got != "abcd" {
+		t.Errorf("got %q, want %q", got, "abcd")
+	}
+	if !truncated {
+		t.Error("expected truncated=true")
+	}
+}

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/morikubo-takashi/gog-lite/internal/output"
+	gapi "google.golang.org/api/googleapi"
+)
+
+func TestWriteGoogleAPIError_NotFound(t *testing.T) {
+	err := withMutedStderr(t, func() error {
+		return writeGoogleAPIError("get_error", &gapi.Error{Code: 404, Message: "not found"})
+	})
+	if got := output.ExitCode(err); got != output.ExitCodeNotFound {
+		t.Errorf("exit code = %d, want %d", got, output.ExitCodeNotFound)
+	}
+}
+
+func TestWriteGoogleAPIError_ForbiddenWrapped(t *testing.T) {
+	err := withMutedStderr(t, func() error {
+		base := &gapi.Error{Code: 403, Message: "forbidden"}
+		return writeGoogleAPIError("get_error", fmt.Errorf("wrapped: %w", base))
+	})
+	if got := output.ExitCode(err); got != output.ExitCodePermission {
+		t.Errorf("exit code = %d, want %d", got, output.ExitCodePermission)
+	}
+}
+
+func TestWriteGoogleAPIError_OtherGoogleAPIError(t *testing.T) {
+	err := withMutedStderr(t, func() error {
+		return writeGoogleAPIError("get_error", &gapi.Error{Code: 500, Message: "internal"})
+	})
+	if got := output.ExitCode(err); got != output.ExitCodeError {
+		t.Errorf("exit code = %d, want %d", got, output.ExitCodeError)
+	}
+}
+
+func TestWriteGoogleAPIError_NonGoogleError(t *testing.T) {
+	err := withMutedStderr(t, func() error {
+		return writeGoogleAPIError("get_error", errors.New("plain error"))
+	})
+	if got := output.ExitCode(err); got != output.ExitCodeError {
+		t.Errorf("exit code = %d, want %d", got, output.ExitCodeError)
+	}
+}
+
+func withMutedStderr(t *testing.T, fn func() error) error {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	runErr := fn()
+
+	_ = w.Close()
+	_, _ = io.Copy(io.Discard, r)
+	_ = r.Close()
+
+	return runErr
+}

--- a/internal/cmd/gmail_test.go
+++ b/internal/cmd/gmail_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import "testing"
+
+func TestValidateHeaderValue_Valid(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "subject", value: "Weekly report"},
+		{name: "to", value: "alice@example.com"},
+		{name: "cc", value: "alice@example.com,bob@example.com"},
+		{name: "account", value: "sender@example.com"},
+		{name: "bcc", value: ""},
+	} {
+		if err := validateHeaderValue(tc.name, tc.value); err != nil {
+			t.Errorf("validateHeaderValue(%q, %q): unexpected error: %v", tc.name, tc.value, err)
+		}
+	}
+}
+
+func TestValidateHeaderValue_RejectsCRLF(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "subject", value: "ok\r\nBcc: evil@example.com"},
+		{name: "to", value: "alice@example.com\nCc:evil@example.com"},
+		{name: "account", value: "sender@example.com\rbad"},
+	} {
+		if err := validateHeaderValue(tc.name, tc.value); err == nil {
+			t.Errorf("validateHeaderValue(%q, %q): expected error, got nil", tc.name, tc.value)
+		}
+	}
+}


### PR DESCRIPTION
## 概要
Gmail送信処理のヘッダインジェクション対策と、cmd層の境界値/終了コードテストを追加しました。

## 変更内容
- gmail send で account/to/cc/bcc/subject に CR/LF を含む値を拒否
  - エラーコード: invalid_header
- docs cat の切り詰め判定をヘルパー化し、境界値テストを追加
  - max-bytes と同値のとき truncated=false
  - max-bytes を超えると truncated=true
- Google APIエラーの終了コードマッピングのテストを追加
  - 404 -> exit code 3
  - 403 -> exit code 4
  - その他 -> exit code 1

## テスト
- go test ./... 実行済み（全件成功）

## 補足
- 未追跡のバイナリファイル gog-lite はコミット対象に含めていません。