### PR TITLE
認証フロー強化とstdin入力サイズ制限

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -96,12 +96,12 @@ func (c *DocsCreateCmd) Run(ctx context.Context, _ *RootFlags) error {
 	content := c.Content
 
 	if c.ContentStdin {
-		b, err := io.ReadAll(os.Stdin)
+		s, err := readStdinWithLimit(maxStdinBytes)
 		if err != nil {
 			return output.WriteError(output.ExitCodeError, "stdin_error", fmt.Sprintf("read stdin: %v", err))
 		}
 
-		content = string(b)
+		content = s
 	}
 
 	docSvc, err := googleapi.NewDocs(ctx, c.Account)
@@ -210,12 +210,12 @@ func (c *DocsWriteCmd) Run(ctx context.Context, root *RootFlags) error {
 	content := c.Content
 
 	if c.ContentStdin {
-		b, err := io.ReadAll(os.Stdin)
+		s, err := readStdinWithLimit(maxStdinBytes)
 		if err != nil {
 			return output.WriteError(output.ExitCodeError, "stdin_error", fmt.Sprintf("read stdin: %v", err))
 		}
 
-		content = string(b)
+		content = s
 	}
 
 	dryRun := root.DryRun

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -110,12 +109,12 @@ func (c *GmailSendCmd) Run(ctx context.Context, _ *RootFlags) error {
 	body := c.Body
 
 	if c.BodyStdin {
-		b, err := io.ReadAll(os.Stdin)
+		s, err := readStdinWithLimit(maxStdinBytes)
 		if err != nil {
 			return output.WriteError(output.ExitCodeError, "stdin_error", fmt.Sprintf("read stdin: %v", err))
 		}
 
-		body = string(b)
+		body = s
 	}
 
 	for _, hv := range []struct {

--- a/internal/cmd/stdin.go
+++ b/internal/cmd/stdin.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const maxStdinBytes = 10 * 1024 * 1024
+
+func readStdinWithLimit(limit int64) (string, error) {
+	if limit <= 0 {
+		return "", fmt.Errorf("invalid stdin limit: %d", limit)
+	}
+
+	limited := io.LimitReader(os.Stdin, limit+1)
+	b, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+
+	if int64(len(b)) > limit {
+		return "", fmt.Errorf("stdin exceeds %d bytes", limit)
+	}
+
+	return string(b), nil
+}

--- a/internal/cmd/stdin_test.go
+++ b/internal/cmd/stdin_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReadStdinWithLimit_OK(t *testing.T) {
+	got, err := withStdin(t, "hello", func() (string, error) {
+		return readStdinWithLimit(10)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestReadStdinWithLimit_Exceeds(t *testing.T) {
+	_, err := withStdin(t, strings.Repeat("a", 11), func() (string, error) {
+		return readStdinWithLimit(10)
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestReadStdinWithLimit_InvalidLimit(t *testing.T) {
+	_, err := readStdinWithLimit(0)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func withStdin(t *testing.T, input string, fn func() (string, error)) (string, error) {
+	t.Helper()
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	if _, err := w.WriteString(input); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	_ = w.Close()
+
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+	defer func() { _ = r.Close() }()
+
+	return fn()
+}


### PR DESCRIPTION
## 概要
ハッカー視点の指摘に基づき、認証フローと入力処理をハードニングしました。

## 変更内容
- OAuth Step2でstateの厳格照合を実施
  - redirect URLのstateを必須化
  - 保存済みstateをstate値で直接引き当て
  - 不一致/期限切れはエラー
- Auth loginで--accountと実トークンEmailの一致検証を追加
  - id_tokenのemail claimを抽出
  - 不一致時は account_mismatch で保存拒否
- stdin入力に上限を追加（10MB）
  - gmail send --body-stdin
  - docs create/write --content-stdin
  - 超過時は stdin_error

## テスト
- googleauth: token email抽出・state読み出しテストを追加
- cmd: stdinサイズ制限テストを追加
- go test ./... 実行済み（全件成功）

## 補足
- 未追跡のローカルバイナリ gog-lite はPRに含めていません。