### PR TITLE
セキュリティ全面強化: 認証/入出力/監査ログをハードニング

### DIFF
--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type auditEntry struct {
+	Timestamp string `json:"timestamp"`
+	Action    string `json:"action"`
+	Account   string `json:"account,omitempty"`
+	Target    string `json:"target,omitempty"`
+	DryRun    bool   `json:"dry_run"`
+}
+
+func appendAuditLog(path string, entry auditEntry) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+
+	if entry.Timestamp == "" {
+		entry.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("ensure audit log directory: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open audit log: %w", err)
+	}
+	defer f.Close()
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode audit log: %w", err)
+	}
+
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write audit log: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cmd/audit_test.go
+++ b/internal/cmd/audit_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendAuditLog_WritesJSONLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+
+	err := appendAuditLog(path, auditEntry{
+		Action:  "docs.write",
+		Account: "you@example.com",
+		Target:  "doc-123",
+		DryRun:  false,
+	})
+	if err != nil {
+		t.Fatalf("appendAuditLog: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit file: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"action":"docs.write"`) {
+		t.Fatalf("missing action in %q", s)
+	}
+	if !strings.Contains(s, `"account":"you@example.com"`) {
+		t.Fatalf("missing account in %q", s)
+	}
+}

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -205,6 +205,14 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, root *RootFlags) error {
 	dryRun := root.DryRun
 
 	if dryRun {
+		if err := appendAuditLog(root.AuditLog, auditEntry{
+			Action:  "calendar.create",
+			Account: normalizeEmail(c.Account),
+			Target:  c.CalendarID,
+			DryRun:  true,
+		}); err != nil {
+			return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
+		}
 		return output.WriteJSON(os.Stdout, map[string]any{
 			"dry_run": true,
 			"action":  "calendar.create",
@@ -236,6 +244,14 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, root *RootFlags) error {
 	created, err := svc.Events.Insert(c.CalendarID, event).Do()
 	if err != nil {
 		return writeGoogleAPIError("create_error", err)
+	}
+	if err := appendAuditLog(root.AuditLog, auditEntry{
+		Action:  "calendar.create",
+		Account: normalizeEmail(c.Account),
+		Target:  created.Id,
+		DryRun:  false,
+	}); err != nil {
+		return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
@@ -276,6 +292,14 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, root *RootFlags) error {
 	dryRun := root.DryRun
 
 	if dryRun {
+		if err := appendAuditLog(root.AuditLog, auditEntry{
+			Action:  "calendar.update",
+			Account: normalizeEmail(c.Account),
+			Target:  c.EventID,
+			DryRun:  true,
+		}); err != nil {
+			return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
+		}
 		return output.WriteJSON(os.Stdout, map[string]any{
 			"dry_run": true,
 			"action":  "calendar.update",
@@ -327,6 +351,14 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, root *RootFlags) error {
 	if err != nil {
 		return writeGoogleAPIError("update_error", err)
 	}
+	if err := appendAuditLog(root.AuditLog, auditEntry{
+		Action:  "calendar.update",
+		Account: normalizeEmail(c.Account),
+		Target:  c.EventID,
+		DryRun:  false,
+	}); err != nil {
+		return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
+	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{
 		"id":      updated.Id,
@@ -348,6 +380,14 @@ func (c *CalendarDeleteCmd) Run(ctx context.Context, root *RootFlags) error {
 	dryRun := root.DryRun
 
 	if dryRun {
+		if err := appendAuditLog(root.AuditLog, auditEntry{
+			Action:  "calendar.delete",
+			Account: normalizeEmail(c.Account),
+			Target:  c.EventID,
+			DryRun:  true,
+		}); err != nil {
+			return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
+		}
 		return output.WriteJSON(os.Stdout, map[string]any{
 			"dry_run": true,
 			"action":  "calendar.delete",
@@ -366,6 +406,14 @@ func (c *CalendarDeleteCmd) Run(ctx context.Context, root *RootFlags) error {
 
 	if err := svc.Events.Delete(c.CalendarID, c.EventID).Do(); err != nil {
 		return writeGoogleAPIError("delete_error", err)
+	}
+	if err := appendAuditLog(root.AuditLog, auditEntry{
+		Action:  "calendar.delete",
+		Account: normalizeEmail(c.Account),
+		Target:  c.EventID,
+		DryRun:  false,
+	}); err != nil {
+		return output.WriteError(output.ExitCodeError, "audit_error", err.Error())
 	}
 
 	return output.WriteJSON(os.Stdout, map[string]any{

--- a/internal/cmd/gmail_test.go
+++ b/internal/cmd/gmail_test.go
@@ -33,3 +33,33 @@ func TestValidateHeaderValue_RejectsCRLF(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAddressList_Valid(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "to", value: "alice@example.com"},
+		{name: "cc", value: "Alice <alice@example.com>, bob@example.com"},
+		{name: "bcc", value: ""},
+	} {
+		if err := validateAddressList(tc.name, tc.value); err != nil {
+			t.Errorf("validateAddressList(%q, %q): unexpected error: %v", tc.name, tc.value, err)
+		}
+	}
+}
+
+func TestValidateAddressList_Invalid(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "to", value: ""},
+		{name: "to", value: "not-an-email"},
+		{name: "cc", value: "alice@example.com, bad"},
+	} {
+		if err := validateAddressList(tc.name, tc.value); err == nil {
+			t.Errorf("validateAddressList(%q, %q): expected error, got nil", tc.name, tc.value)
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,8 +10,9 @@ import (
 
 // RootFlags are flags available to all commands.
 type RootFlags struct {
-	Verbose bool `name:"verbose" short:"v" help:"Enable verbose logging."`
-	DryRun  bool `name:"dry-run" short:"n" help:"Print what would be done without executing."`
+	Verbose  bool   `name:"verbose" short:"v" help:"Enable verbose logging."`
+	DryRun   bool   `name:"dry-run" short:"n" help:"Print what would be done without executing."`
+	AuditLog string `name:"audit-log" help:"Append write-action audit logs as JSON lines to this file path."`
 }
 
 // CLI is the top-level command structure.

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,24 @@
+package secrets
+
+import "testing"
+
+func TestRequireFileBackendPassword_RequiresEnv(t *testing.T) {
+	t.Setenv(keyringPasswordEnv, "")
+	if err := requireFileBackendPassword("file"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRequireFileBackendPassword_NotRequiredForOtherBackends(t *testing.T) {
+	t.Setenv(keyringPasswordEnv, "")
+	if err := requireFileBackendPassword("keychain"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequireFileBackendPassword_AllowsWhenSet(t *testing.T) {
+	t.Setenv(keyringPasswordEnv, "secret")
+	if err := requireFileBackendPassword("file"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要
ハッカー目線・ランサムウェア目線・不正利用者目線で挙げた改善点をすべて実装しました。

## 実装内容
1. OAuth Step2 の強化
- state 必須化・state一致の保存状態のみ許可
- userinfo API で email を取得（id_tokenの手パース廃止）
- email_verified も確認

2. docs export の安全化
- 既存ファイルはデフォルトで上書き禁止
- --overwrite 指定時のみ上書き許可
- 一時ファイル + rename の原子的書き込み

3. docs write --replace の誤操作対策
- --replace 利用時は --confirm-replace を必須化

4. Gmail宛先の妥当性検証
- CR/LF防止に加えて、to/cc/bcc を mail.ParseAddressList で検証

5. 監査ログ機能追加
- グローバルフラグ --audit-log PATH を追加
- write系操作で JSONL 監査ログを追記
- 記録項目: timestamp/action/account/target/dry_run

6. file keyring backend の運用ガード
- GOG_LITE_KEYRING_BACKEND=file 時に
  GOG_LITE_KEYRING_PASSWORD 未設定なら明示エラー

## テスト
- 追加: oauth userinfo/state, audit log, recipient validation, file export overwrite, keyring guard
- 実行: go test ./...（全件成功）

## 補足
- 未追跡のローカルバイナリ gog-lite はPRに含めていません。