### PR TITLE
fix(config_test): set XDG_CONFIG_HOME to isolate tests on Linux

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,9 @@ func TestReadCredentials_PartialEnvVarFallsBackToFile(t *testing.T) {
 	// Only one env var set → must not use env vars, should fall back to file.
 	t.Setenv("GOG_LITE_CLIENT_ID", "only-id")
 	t.Setenv("GOG_LITE_CLIENT_SECRET", "")
-	t.Setenv("HOME", t.TempDir())
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome) // Linux: override XDG config home
 
 	// Use config.CredentialsPath() to find the platform-correct path.
 	credsPath, err := config.CredentialsPath()
@@ -71,7 +73,9 @@ func TestReadCredentials_PartialEnvVarFallsBackToFile(t *testing.T) {
 func TestReadCredentials_FileGoogleFormat(t *testing.T) {
 	t.Setenv("GOG_LITE_CLIENT_ID", "")
 	t.Setenv("GOG_LITE_CLIENT_SECRET", "")
-	t.Setenv("HOME", t.TempDir())
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome) // Linux: override XDG config home
 
 	credsPath, err := config.CredentialsPath()
 	if err != nil {
@@ -101,7 +105,9 @@ func TestReadCredentials_FileGoogleFormat(t *testing.T) {
 func TestReadCredentials_MissingFileError(t *testing.T) {
 	t.Setenv("GOG_LITE_CLIENT_ID", "")
 	t.Setenv("GOG_LITE_CLIENT_SECRET", "")
-	t.Setenv("HOME", t.TempDir())
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome) // Linux: override XDG config home
 
 	_, err := config.ReadCredentials()
 	if err == nil {


### PR DESCRIPTION
## 概要

`config_test.go` のテストが Linux CI で失敗する問題を修正します。

## 原因

Linux では `os.UserConfigDir()` が `$XDG_CONFIG_HOME`（設定されている場合）を `$HOME` より優先します。
GitHub Actions の Ubuntu ランナーで `XDG_CONFIG_HOME` が設定されていると、テスト内で `HOME` を temp dir に変更しても `CredentialsPath()` が実際の XDG config ディレクトリを指したままになります。

その結果、前のテスト（`TestReadCredentials_FileGoogleFormat`）が実際の XDG config dir に credentials.json を作成し、次のテスト（`TestReadCredentials_MissingFileError`）がそのファイルを見つけて nil エラーを返すため失敗していました。

## 修正

ファイル操作を伴う 3 つのテストで、`HOME` に加えて `XDG_CONFIG_HOME` も同じ temp dir に設定します。

## テスト

```
go test ./internal/config/...  # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)