### PR TITLE
test: Phase 2/3 CI tests + security regression (closes #9, #10, #11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           assert d['code'] == 'find_replace_requires_confirmation', f\"got code {d['code']}\"
           print('confirm-find-replace: OK')
           "
-      - name: policy denies blocked action
+      - name: policy denies blocked action (calendar.delete)
         run: |
           export HOME=$(mktemp -d)
           export XDG_CONFIG_HOME="$HOME"
@@ -99,8 +99,99 @@ jobs:
           import json
           d = json.load(open('/tmp/err.json'))
           assert d['code'] == 'policy_denied', f\"got code {d['code']}\"
-          print('policy-denied: OK')
+          print('policy-denied calendar.delete: OK')
           "
+      - name: policy denies write commands
+        run: |
+          export HOME=$(mktemp -d)
+          export XDG_CONFIG_HOME="$HOME"
+          export GOG_LITE_CLIENT_ID=dummy-id
+          export GOG_LITE_CLIENT_SECRET=dummy-secret
+          mkdir -p "$HOME/gog-lite"
+          echo '{"allowed_actions":["calendar.get"]}' > "$HOME/gog-lite/policy.json"
+          check_policy_denied() {
+            cmd="$1"; label="$2"
+            eval "$cmd" 2>/tmp/err.json && code=0 || code=$?
+            [ "$code" -ne 0 ] || { echo "FAIL: $label expected non-zero exit"; exit 1; }
+            python3 -c "
+          import json
+          d = json.load(open('/tmp/err.json'))
+          assert d['code'] == 'policy_denied', f\"$label: got code {d['code']}\"
+          print('policy-denied $label: OK')
+            "
+          }
+          check_policy_denied \
+            "/tmp/gog-lite gmail send --account test@example.com --to a@b.com --subject x --body y" \
+            "gmail.send"
+          check_policy_denied \
+            "/tmp/gog-lite calendar create --account test@example.com --title t --start 2026-03-01T10:00:00Z --end 2026-03-01T11:00:00Z" \
+            "calendar.create"
+          check_policy_denied \
+            "/tmp/gog-lite calendar update --account test@example.com --event-id x --title t" \
+            "calendar.update"
+          check_policy_denied \
+            "/tmp/gog-lite docs create --account test@example.com --title t" \
+            "docs.create"
+          check_policy_denied \
+            "/tmp/gog-lite docs write --account test@example.com --doc-id x --content hello" \
+            "docs.write"
+          check_policy_denied \
+            "/tmp/gog-lite docs find-replace --account test@example.com --doc-id x --find a --replace b" \
+            "docs.find-replace"
+          check_policy_denied \
+            "/tmp/gog-lite docs export --account test@example.com --doc-id x --format pdf --output /tmp/out.pdf" \
+            "docs.export"
+      - name: approval-token required when missing
+        run: |
+          export HOME=$(mktemp -d)
+          export XDG_CONFIG_HOME="$HOME"
+          /tmp/gog-lite calendar delete --account test@example.com --event-id x --confirm-delete 2>/tmp/err.json && code=0 || code=$?
+          echo "exit code: $code"
+          cat /tmp/err.json
+          [ "$code" -ne 0 ]
+          python3 -c "
+          import json
+          d = json.load(open('/tmp/err.json'))
+          assert d['code'] == 'approval_required', f\"got code {d['code']}\"
+          print('approval-required-missing-token: OK')
+          "
+      - name: approval-token reuse rejected
+        run: |
+          export HOME=$(mktemp -d)
+          export XDG_CONFIG_HOME="$HOME"
+          export GOG_LITE_CLIENT_ID=dummy-id
+          export GOG_LITE_CLIENT_SECRET=dummy-secret
+          token=$(/tmp/gog-lite auth approval-token --account test@example.com --action calendar.delete --ttl 10m \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")
+          echo "issued token"
+          # First use: token is consumed; command then fails at auth (no real credentials).
+          /tmp/gog-lite calendar delete --account test@example.com --event-id x --confirm-delete \
+            --approval-token "$token" 2>/dev/null && true || true
+          # Second use: token already used → approval_required.
+          /tmp/gog-lite calendar delete --account test@example.com --event-id x --confirm-delete \
+            --approval-token "$token" 2>/tmp/err.json && code=0 || code=$?
+          echo "exit code: $code"
+          cat /tmp/err.json
+          [ "$code" -ne 0 ]
+          python3 -c "
+          import json
+          d = json.load(open('/tmp/err.json'))
+          assert d['code'] == 'approval_required', f\"got code {d['code']}\"
+          print('approval-token-reuse: OK')
+          "
+      - name: dry-run skips confirm and approval-token
+        run: |
+          export HOME=$(mktemp -d)
+          export XDG_CONFIG_HOME="$HOME"
+          out=$(/tmp/gog-lite --dry-run calendar delete --account test@example.com --event-id x)
+          echo "$out"
+          python3 -c "
+          import json, sys
+          d = json.loads(sys.argv[1])
+          assert d.get('dry_run') == True, 'expected dry_run=true'
+          assert d.get('action') == 'calendar.delete', f\"expected action calendar.delete, got {d.get('action')}\"
+          print('dry-run-skips-token: OK')
+          " "$out"
 
   security-nightly:
     name: Security Regression (nightly)
@@ -112,10 +203,29 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run security regression tests
-        run: go test ./... -v -run 'TestAudit|TestApproval|TestPolicy|TestRateLimit|TestStdinLimit'
+        run: go test ./... -v -run 'TestAudit|TestApproval|TestPolicy|TestRateLimit|TestReadStdinWithLimit'
         env:
           GOG_LITE_KEYRING_BACKEND: file
           GOG_LITE_KEYRING_PASSWORD: ci-test-password
+      - name: Build CLI binary
+        run: go build -o /tmp/gog-lite ./cmd/gog-lite/
+      - name: keyring file backend requires password
+        run: |
+          export HOME=$(mktemp -d)
+          export XDG_CONFIG_HOME="$HOME"
+          export GOG_LITE_KEYRING_BACKEND=file
+          unset GOG_LITE_KEYRING_PASSWORD
+          /tmp/gog-lite auth list 2>/tmp/err.json && code=0 || code=$?
+          echo "exit code: $code"
+          cat /tmp/err.json
+          [ "$code" -ne 0 ]
+          python3 -c "
+          import json
+          d = json.load(open('/tmp/err.json'))
+          assert d['code'] == 'keyring_error', f\"got code {d['code']}\"
+          assert 'GOG_LITE_KEYRING_PASSWORD' in d.get('error', ''), f\"unexpected error: {d}\"
+          print('keyring-file-no-password: OK')
+          "
       - name: Upload security test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ export GOG_LITE_KEYRING_PASSWORD=your-secure-password
 
 コマンド仕様・エラーコード・ページネーション・stdin活用など詳細は [`AGENTS.md`](AGENTS.md) を参照。
 
+## CI セキュリティテスト方針
+
+| ジョブ | トリガー | 内容 |
+|---|---|---|
+| `unit-fast` | PR / push | `go test ./...` + vet でユニットテストを高速実行 |
+| `integration-cli` | PR / push | 実バイナリを temp HOME で実行し、policy_denied・approval_required・preflight スキーマなどの結合挙動を検証 |
+| `security-nightly` | 毎日 02:00 UTC | 監査ログ改ざん検知・承認トークン再利用・stdin 上限・キーリング設定ミスの回帰テスト |
+
+失敗時は JSON エラー本文を GitHub Actions Artifacts に保存します。
+
 ## ライセンス
 
 MIT

--- a/internal/cmd/audit_test.go
+++ b/internal/cmd/audit_test.go
@@ -94,6 +94,55 @@ func TestResolveAuditLogPath_RejectsOutsideConfigDir(t *testing.T) {
 	}
 }
 
+func TestAuditHashChain_TamperDetect(t *testing.T) {
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	path, err := resolveAuditLogPath("")
+	if err != nil {
+		t.Fatalf("resolveAuditLogPath: %v", err)
+	}
+
+	if err := appendAuditLog(path, auditEntry{Action: "original"}); err != nil {
+		t.Fatalf("append #1: %v", err)
+	}
+	if err := appendAuditLog(path, auditEntry{Action: "second"}); err != nil {
+		t.Fatalf("append #2: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(lines))
+	}
+
+	var first auditEntry
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("decode first line: %v", err)
+	}
+	var second auditEntry
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatalf("decode second line: %v", err)
+	}
+
+	// Tamper: change the action field of the first entry (the stored hash is now stale).
+	tampered := first
+	tampered.Action = "tampered"
+
+	// The recomputed hash must differ from the stored hash → tampering is detectable.
+	if computeAuditHash(tampered) == first.Hash {
+		t.Fatal("tampered entry should produce a different hash")
+	}
+	// The second entry's prev_hash no longer matches the tampered first entry → chain is broken.
+	if second.PrevHash == computeAuditHash(tampered) {
+		t.Fatal("chain should be broken after tampering with first entry")
+	}
+}
+
 func TestResolveAuditLogPath_AllowsPathUnderConfigDir(t *testing.T) {
 	cfgHome := t.TempDir()
 	t.Setenv("HOME", cfgHome)

--- a/internal/cmd/stdin_test.go
+++ b/internal/cmd/stdin_test.go
@@ -27,6 +27,51 @@ func TestReadStdinWithLimit_Exceeds(t *testing.T) {
 	}
 }
 
+// withStdinAsync writes input to a pipe in a goroutine to avoid blocking on large payloads.
+func withStdinAsync(t *testing.T, input string, fn func() (string, error)) (string, error) {
+	t.Helper()
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	go func() {
+		_, _ = w.WriteString(input)
+		_ = w.Close()
+	}()
+
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+	defer func() { _ = r.Close() }()
+
+	return fn()
+}
+
+func TestReadStdinWithLimit_AtMaxStdinBytes(t *testing.T) {
+	input := strings.Repeat("a", int(maxStdinBytes))
+	got, err := withStdinAsync(t, input, func() (string, error) {
+		return readStdinWithLimit(maxStdinBytes)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error at maxStdinBytes: %v", err)
+	}
+	if got != input {
+		t.Fatalf("got %d bytes, want %d", len(got), len(input))
+	}
+}
+
+func TestReadStdinWithLimit_OverMaxStdinBytes(t *testing.T) {
+	input := strings.Repeat("a", int(maxStdinBytes)+1)
+	_, err := withStdinAsync(t, input, func() (string, error) {
+		return readStdinWithLimit(maxStdinBytes)
+	})
+	if err == nil {
+		t.Fatal("expected error for input exceeding maxStdinBytes, got nil")
+	}
+}
+
 func TestReadStdinWithLimit_InvalidLimit(t *testing.T) {
 	_, err := readStdinWithLimit(0)
 	if err == nil {


### PR DESCRIPTION
## Summary

### ユニットテスト（Phase 3 security regression）
- `audit_test.go`: `TestAuditHashChain_TamperDetect` — 監査ログのエントリを改ざんした際に `computeAuditHash` が異なる値を返し、チェーンの破損を検出できることを検証
- `stdin_test.go`: `TestReadStdinWithLimit_AtMaxStdinBytes` / `OverMaxStdinBytes` — 10MB 境界での上限制御を検証（goroutine ベースの `withStdinAsync` ヘルパーを使用してデッドロック回避）

### CI 統合テスト（Phase 2）
- `policy_denied`: `gmail.send` / `calendar.create` / `calendar.update` / `docs.create` / `docs.write` / `docs.find-replace` / `docs.export` の全書き込みコマンドを網羅
- `approval_required`: token 未指定での拒否を検証
- `approval_required`: token 再利用での拒否を検証
- `dry-run`: `--dry-run` でトークン・confirm フラグなしでも成功することを検証

### nightly セキュリティ回帰（Phase 3）
- `GOG_LITE_KEYRING_BACKEND=file` かつ `GOG_LITE_KEYRING_PASSWORD` 未設定時の失敗を検証
- nightly の run パターンを `TestStdinLimit` → `TestReadStdinWithLimit` に修正

### README
- CI セキュリティテスト方針（ジョブ責務分離）を追記

## Test plan

- [x] `go test ./...` ローカルで全パスを確認
- [ ] CI (unit-fast / integration-cli) が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)