### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Build output
+gog-lite
+/bin/
+dist/
+
+# Go
+vendor/
+*.test
+coverage.out
+*.out
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Environment / secrets
+.env
+.env.*
+
+# Google OAuth credentials (never commit these)
+credentials.json
+client_secret_*.json
+
+# Runtime data (should live in ~/.config/gog-lite/, not the repo)
+audit.log
+*.log
+policy.json
+ratelimit/
+approvals/


### PR DESCRIPTION
## Summary

- ビルドバイナリ (`gog-lite`, `dist/`) を除外
- Google OAuth 認証情報 (`credentials.json`, `client_secret_*.json`) の誤コミットを防止
- macOS `.DS_Store`、エディタ設定 (`.idea/`, `.vscode/`)、`.env` ファイルを除外
- ランタイムデータ (`audit.log`, `policy.json`, `ratelimit/`, `approvals/`) を除外（`~/.config/gog-lite/` 配下に置くべきものが誤ってリポジトリに含まれる事故を防ぐ）

## Test plan

- [x] `git status` でバイナリや `.DS_Store` が untracked のまま残ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)