### PR TITLE
build: inject version via ldflags and default to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,21 @@ AIエージェントが Gmail / Google Calendar / Google Docs を操作するた
 ```bash
 git clone https://github.com/kubot64/gog-lite
 cd gog-lite
-go build -o ~/bin/gog-lite ./cmd/gog-lite/
+go build -ldflags "-X main.version=$(git describe --tags --always --dirty)" -o ~/bin/gog-lite ./cmd/gog-lite/
+```
+
+タグがない開発ブランチでは `--version` は `dev`（または `git describe` の値）になります。
+
+## バージョン運用
+
+- `--version` の値はビルド時の `-ldflags "-X main.version=..."` で注入する。
+- リリース時は Git タグ（例: `v0.2.0`）を作成し、タグ値を version に使う。
+- 例:
+
+```bash
+VERSION=$(git describe --tags --always --dirty)
+go build -ldflags "-X main.version=$VERSION" -o ~/bin/gog-lite ./cmd/gog-lite/
+gog-lite --version
 ```
 
 ## セットアップ

--- a/cmd/gog-lite/main.go
+++ b/cmd/gog-lite/main.go
@@ -8,9 +8,12 @@ import (
 	"github.com/kubot64/gog-lite/internal/output"
 )
 
+// version is injected at build time via -ldflags "-X main.version=<value>".
+var version = "dev"
+
 func main() {
 	ctx := context.Background()
-	if err := cmd.Execute(ctx); err != nil {
+	if err := cmd.Execute(ctx, version); err != nil {
 		os.Exit(output.ExitCode(err))
 	}
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@
 ```bash
 git clone https://github.com/kubot64/gog-lite
 cd gog-lite
-go build -o ~/bin/gog-lite ./cmd/gog-lite/
+go build -ldflags "-X main.version=$(git describe --tags --always --dirty)" -o ~/bin/gog-lite ./cmd/gog-lite/
 ```
 
 `~/bin` にパスが通っていない場合は以下を `~/.zshrc` または `~/.bashrc` に追加してください。
@@ -30,7 +30,7 @@ export PATH="$HOME/bin:$PATH"
 
 ```bash
 gog-lite --version
-# gog-lite 0.1.0
+# v0.2.0 / dev / <tag>-<sha> など（ビルド時に注入した値）
 ```
 
 ---

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kong"
 )
@@ -27,14 +28,14 @@ type CLI struct {
 }
 
 // Execute parses CLI arguments and runs the selected command.
-func Execute(ctx context.Context) error {
+func Execute(ctx context.Context, version string) error {
 	cli := &CLI{}
 
 	k, err := kong.New(cli,
 		kong.Name("gog-lite"),
 		kong.Description("AI-agent-friendly CLI for Gmail, Calendar, and Docs."),
 		kong.UsageOnError(),
-		kong.Vars{"version": "0.1.0"},
+		kong.Vars{"version": resolveVersion(version)},
 	)
 	if err != nil {
 		return fmt.Errorf("create parser: %w", err)
@@ -50,6 +51,15 @@ func Execute(ctx context.Context) error {
 	kctx.Bind(&cli.RootFlags)
 
 	return kctx.Run()
+}
+
+func resolveVersion(version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return "dev"
+	}
+
+	return v
 }
 
 // collectAllPages calls fn repeatedly until nextPageToken is empty or allPages is false.

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "uses provided version", in: "v1.2.3", want: "v1.2.3"},
+		{name: "trim spaces", in: "  1.0.0  ", want: "1.0.0"},
+		{name: "empty falls back to dev", in: "", want: "dev"},
+		{name: "whitespace falls back to dev", in: "   ", want: "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveVersion(tt.in)
+			if got != tt.want {
+				t.Fatalf("resolveVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- replace hardcoded CLI version with a build-time injected value
- add fallback logic to return `dev` when no version is injected
- pass version from `main` into command wiring
- add tests for version resolution behavior
- update docs to use `go build -ldflags "-X main.version=..."`

## Why
Hardcoded versions drift from tags/releases. This change makes version output deterministic per build artifact and aligns with tag-based release workflows.

## Validation
- `go test ./cmd/gog-lite ./internal/cmd`
- local build without ldflags prints `dev`
- local build with `-X main.version=v0.2.0` prints `v0.2.0`

## Files
- cmd/gog-lite/main.go
- internal/cmd/root.go
- internal/cmd/version_test.go
- README.md
- docs/getting-started.md
