### PR TITLE
ci: trigger release workflow from Tag Release completion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,10 @@ jobs:
           ref: main
       - name: Resolve tag from head SHA
         id: resolve
+        env:
+          SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          SHA="${{ github.event.workflow_run.head_sha }}"
           TAG=$(git tag --points-at "$SHA" | grep '^v' | sort -r | head -n1 || true)
 
           if [ -z "${TAG}" ]; then
@@ -59,7 +60,9 @@ jobs:
 
   update-formula:
     name: Update Homebrew Formula
-    needs: goreleaser
+    needs:
+      - goreleaser
+      - resolve-tag
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.resolve-tag.outputs.tag }}


### PR DESCRIPTION
## Purpose
Run release jobs after tag creation without using a PAT.

## Changes
- Switch `.github/workflows/release.yml` trigger from `push tags` to `workflow_run` (`Tag Release` completed)
- Add `resolve-tag` job to resolve `v*` tag from `workflow_run.head_sha`
- Use resolved tag in GoReleaser checkout and Formula update metadata

## Test
- Verified YAML diff locally and references (`needs.resolve-tag.outputs.tag`) are wired correctly.
- End-to-end run should be verified by dispatching `Tag Release` once merged.

## Impact
- Release is now chained from `Tag Release` with `GITHUB_TOKEN` only.
- No PAT required for release triggering.