### PR TITLE
ci: fix release workflow parse error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  resolve-tag:
+  resolve_tag:
     name: Resolve Tag
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
@@ -41,13 +41,13 @@ jobs:
 
   goreleaser:
     name: GoReleaser
-    needs: resolve-tag
+    needs: resolve_tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.resolve-tag.outputs.tag }}
+          ref: ${{ needs.resolve_tag.outputs.tag }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -62,10 +62,10 @@ jobs:
     name: Update Homebrew Formula
     needs:
       - goreleaser
-      - resolve-tag
+      - resolve_tag
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ needs.resolve-tag.outputs.tag }}
+      TAG: ${{ needs.resolve_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Purpose
Fix invalid workflow expression parsing in release.yml.

## Changes
- Rename job id `resolve-tag` -> `resolve_tag`
- Update all `needs.*` references to `needs.resolve_tag.*`

## Why
Job IDs with hyphen in dot-notation expression caused workflow parsing failure (`workflow file issue`, jobs=0).

## Test
- Confirmed release.yml now uses underscore job id and consistent needs references.
- After merge, trigger Tag Release and confirm Release starts via `workflow_run`.

## Impact
- Removes push-time invalid workflow failure
- Enables Tag Release -> Release chaining as intended.