### PR TITLE
ci: harden release action pinning and prevent ref breakage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
       - name: Lint workflows with actionlint
         uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
+  action-refs:
+    name: Action Ref Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate action refs are resolvable
+        run: ./scripts/check-action-refs.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   unit-fast:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
             printf 'end\n'
           } > Formula/gog-lite.rb
       - name: Create PR for Formula update
-        uses: peter-evans/create-pull-request@67df67d0e8e05e405e4c941fe2de7e4e9f6a0b2e # v7.0.7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: "brew: update formula to ${{ env.TAG }}"
           title: "brew: update formula to ${{ env.TAG }}"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ GitHub Actions の YAML 構文と workflow 設定を事前に確認できます�
 
 ```bash
 ./scripts/check-workflows.sh
+./scripts/check-action-refs.sh
 ```
 
 `actionlint` をインストール済みの場合は、構文チェックに加えて workflow lint も実行します。

--- a/scripts/check-action-refs.sh
+++ b/scripts/check-action-refs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+token_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  token_header=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+
+failed=0
+
+while IFS= read -r spec; do
+  case "$spec" in
+    ./*|docker://*)
+      continue
+      ;;
+  esac
+
+  case "$spec" in
+    *@*)
+      repo="${spec%@*}"
+      ref="${spec#*@}"
+      ;;
+    *)
+      continue
+      ;;
+  esac
+
+  url="https://api.github.com/repos/${repo}/commits/${ref}"
+  http_code="$(
+    curl -sS -o "$tmp_body" -w "%{http_code}" \
+      -H "Accept: application/vnd.github+json" \
+      "${token_header[@]}" \
+      "$url"
+  )"
+
+  if [ "$http_code" -ge 400 ]; then
+    echo "[invalid] ${spec} (HTTP ${http_code})"
+    failed=1
+  else
+    echo "[ok] ${spec}"
+  fi
+done < <(
+  rg -No --no-filename --pcre2 'uses:\s*([^\s#]+)' .github/workflows/*.yml -r '$1' \
+    | sort -u
+)
+
+if [ "$failed" -ne 0 ]; then
+  echo "One or more action references are not resolvable."
+  exit 1
+fi
+
+echo "All external action references are resolvable."


### PR DESCRIPTION
## Purpose
Prevent recurrence of release failures caused by broken GitHub Action references.

## Changes
- Fix release workflow action pin
  - update peter-evans/create-pull-request to resolvable SHA (v7.0.11)
- Add action reference validation in CI
  - new script: scripts/check-action-refs.sh
  - new CI job: Action Ref Check
  - validates every external uses reference in .github/workflows/*.yml via GitHub API
- Add Dependabot updates for GitHub Actions
  - new .github/dependabot.yml (weekly)
- Update README local checks
  - add ./scripts/check-action-refs.sh

## Local Verification
- ./scripts/check-workflows.sh passed
- ./scripts/check-action-refs.sh passed (with network access)

## Impact
- catches invalid action refs at PR time
- keeps workflow pins fresh automatically
- unblocks Homebrew formula update step in Release workflow